### PR TITLE
Rebuild documentation from scratch

### DIFF
--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -1,0 +1,16 @@
+API Reference
+=============
+
+Top-level package:
+
+.. automodule:: rshf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utility helpers:
+
+.. automodule:: rshf.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -1,38 +1,15 @@
 Installation
 ============
 
-rshf set-up
-------------
-
-rshf is available for python>=3.9 and requires numpy<2.0 due to dependency issues.
-
-rshf can either be downloaded directly from the `GitHub repository <https://github.com/MVRL/rshf>`_, or installed PyPI package manager (pip).
-
-
-Installing rshf through pip
-----------------------------
-
-rshf is available through pip and can be installed with the following simple command:
-
+Install the latest release from PyPI:
 
 .. code-block:: bash
 
    pip install rshf
 
-Cloning rshf from GitHub
---------------------------
+Verify the installation:
 
-rshf can be cloned from `rshf GitHub repository <https://github.com/MVRL/rshf>`_, or using git. 
+.. code-block:: python
 
-
-.. code-block:: bash
-
-   git clone https://github.com/MVRL/rshf.git
-
-
-The repository can be installed in your python environment by navigating to the top level of the repository and using pip to install the local package.
-
-
-.. code-block:: bash
-   
-   python -m pip install -e .
+   from rshf import list_models
+   print(len(list_models()))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,35 +1,37 @@
-# Configuration file for the Sphinx documentation builder.
+from pathlib import Path
+import sys
 
-# -- Project information
 
-project = 'rshf'
-copyright = '2024, Srikumar'
-author = 'Srikumar'
+# -- Project information -----------------------------------------------------
 
-release = '0.1'
-version = '0.0.5'
+project = "rshf"
+copyright = "2026, rshf contributors"
+author = "rshf contributors"
+release = "0.1"
 
-# -- General configuration
+
+# -- General configuration ---------------------------------------------------
+
+# Ensure autodoc can import the local package when building from `docs/`.
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
 
 extensions = [
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
 ]
 
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+templates_path = ["_templates"]
+exclude_patterns = []
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "show-inheritance": True,
 }
-intersphinx_disabled_domains = ['std']
 
-templates_path = ['_templates']
 
-# -- Options for HTML output
+# -- Options for HTML output -------------------------------------------------
 
-html_theme = 'sphinx_rtd_theme'
-
-# -- Options for EPUB output
-epub_show_urls = 'footnote'
+html_theme = "alabaster"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,21 +1,13 @@
-rshf: Remote Sensing Foundation Models Easy Benchmarking using Huggingface
-==============================================================================
+rshf Documentation
+==================
 
-Welcome to the documentation for rshf!
-=======================================
-
-**rshf** is a Python library for benchmarking remote sensing foundation models using Huggingface. It provides a simple and intuitive API for benchmarking foundation models on remote sensing tasks.
+`rshf` provides lightweight loading helpers for remote sensing foundation
+models hosted on Hugging Face.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Contents
 
-   Installation
-   API
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   installation
+   usage
+   api

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,15 @@
+Usage
+=====
+
+Minimal example:
+
+.. code-block:: python
+
+   import torch
+   from rshf.satmae import SatMAE
+
+   model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")
+   image = torch.randint(0, 256, (224, 224, 3)).float().numpy()
+   batch = model.transform(image, 224).unsqueeze(0)
+   embedding = model.forward_encoder(batch, mask_ratio=0.0)[0]
+   print(embedding.shape)


### PR DESCRIPTION
## Summary
- Replace the previous docs structure with a fresh minimal Sphinx layout (`index`, `Installation`, `usage`, `API`)
- Simplify `docs/source/conf.py` and configure autodoc import path for local package docs generation
- Keep the docs scope intentionally small and maintainable as a new baseline

## Test plan
- [x] Run `make html` from `docs/`
- [x] Confirm `docs/build/html` is generated without Sphinx errors

Made with [Cursor](https://cursor.com)