### PR TITLE
docs: rewrite package documentation for model loading and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,179 @@
 # rshf
+
 [![PyPI - Version](https://img.shields.io/pypi/v/rshf)](https://pypi.org/project/rshf/)
 [![PyPI Downloads](https://static.pepy.tech/badge/rshf)](https://pypistats.org/packages/rshf)
 [![PyPI Docs](https://img.shields.io/readthedocs/rshf)](https://rshf-docs.readthedocs.io/en/latest/)
 
+`rshf` provides a single Python package for loading remote sensing foundation
+models from Hugging Face and related backends.
 
-### Remote sensing pretrained models easy loading using huggingface -- PyTorch (for fast benchmarking)
+This documentation focuses on:
 
-### Installation:
+1. How to load every model exposed by `rshf`.
+2. What utility functions are available in the package.
+
+## Installation
+
 ```bash
 pip install rshf
 ```
 
-### Example:
+## Quick start
+
 ```python
+from rshf import list_models
 from rshf.satmae import SatMAE
+
+# Print matching model repositories in the curated collection.
+list_models("satmae")
+
+# Load pretrained weights.
 model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")
-input = model.transform(torch.randint(0, 256, (224, 224, 3)).float().numpy(), 224).unsqueeze(0)
-print(model.forward_encoder(input, mask_ratio=0.0)[0].shape)
 ```
 
-### TODO:
-- [ ] Add transforms for each model
-- [ ] Add Documentation (https://rshf-docs.readthedocs.io/en/latest/)
-- [x] Add initial set of models
+## Model loading reference
 
-### Citations
+Most classes in `rshf` are loaded with:
 
-|Model Type|Venue|Citation|
-|----------|-----|--------|
-|BioCLIP|CVPR'24|[link](./rshf/bioclip/README.md)
-|Climplicit|ICLRW'25|[link](./rshf/climplicit/README.md)
-|CLIP|ICML'21|[link](./rshf/clip/README.md)
-|CROMA|NeurIPS'23|[link](./rshf/croma/README.md)
-|DinoV3 Sat||[link](./rshf/dinov3_sat/README.md)
-|GeoCLAP|BMVC'23|[link](./rshf/geoclap/README.md)
-|GeoCLIP|NeurIPS'23|[link](./rshf/geoclip/README.md)
-|Presto||[link](./rshf/presto/README.md)
-|Prithvi||[link](./rshf/prithvi/README.md)
-|ProM3E|CVPR'26|[link](./rshf/prom3e/README.md)
-|RCME|ICCV'25|[link](./rshf/rcme/README.md)
-|RemoteCLIP|TGRS'23|[link](./rshf/remoteclip/README.md)
-|RVSA|TGRS'22|[link](./rshf/rvsa/README.md)
-|Sat2Cap|EarthVision'24|[link](./rshf/sat2cap/README.md)
-|SatClip|AAAI'25|[link](./rshf/satclip/README.md)
-|SatMAE|NeurIPS'22|[link](./rshf/satmae/README.md)
-|SatMAE++|CVPR'24|[link](./rshf/satmaepp/README.md)
-|ScaleMAE|ICCV'23|[link](./rshf/scalemae/README.md)
-|SenCLIP|WACV'25|[link](./rshf/senclip/README.md)
-|SINR|ICML'23|[link](./rshf/sinr/README.md)
-|StreetCLIP||[link](./rshf/streetclip/README.md)
-|TaxaBind|WACV'25|[link](./rshf/taxabind/README.md)
-### List of models available here: [Link](https://huggingface.co/collections/MVRL/remote-sensing-foundation-models-664e8fcd67d8ca8c03f42d00)
+```python
+model = ModelClass.from_pretrained("<hf-repo-id>")
+```
+
+Use `list_models("<keyword>")` to discover matching repositories in the
+collection:
+https://huggingface.co/collections/MVRL/remote-sensing-foundation-models-664e8fcd67d8ca8c03f42d00
+
+### Per-model imports and loaders
+
+| Model | Import | Load |
+|---|---|---|
+| BioCLIP | `from rshf.bioclip import BioCLIP` | `model = BioCLIP()` |
+| Climplicit | `from rshf.climplicit import Climplicit` | `model = Climplicit.from_pretrained("<hf-repo-id>")` |
+| CLIP (generic) | `from rshf.clip import CLIPModel` | `model = CLIPModel.from_pretrained("<hf-repo-id>")` |
+| CROMA | `from rshf.croma import CROMA` | `model = CROMA.from_pretrained("<hf-repo-id>")` |
+| DinoV3 Sat | `from rshf.dinov3_sat import Dinov3_Sat` | `model = Dinov3_Sat.from_pretrained("<hf-repo-id>")` |
+| GeoCLAP | `from rshf.geoclap import GeoCLAP` | `model = GeoCLAP.from_pretrained("<hf-repo-id>")` |
+| GeoCLIP | `from rshf.geoclip import GeoCLIP` | `model = GeoCLIP.from_pretrained("<hf-repo-id>")` |
+| Presto | `from rshf.presto import Presto` | `model = Presto.from_pretrained("<hf-repo-id>")` |
+| Prithvi | `from rshf.prithvi import Prithvi` | `model = Prithvi.from_pretrained("<hf-repo-id>")` |
+| ProM3E | `from rshf.prom3e import ProM3E` | `model = ProM3E.from_pretrained("<hf-repo-id>")` |
+| RCME | `from rshf.rcme import RCME` | `model = RCME()` |
+| RemoteCLIP | `from rshf.remoteclip import RemoteCLIP` | `model = RemoteCLIP("ViT-B-32")` |
+| RVSA | `from rshf.rvsa import RVSA` | `model = RVSA.from_pretrained("<hf-repo-id>")` |
+| Sat2Cap (vision encoder) | `from rshf.sat2cap import Sat2Cap` | `model = Sat2Cap.from_pretrained("<hf-repo-id>")` |
+| SatClip | `from rshf.satclip import SatClip` | `model = SatClip.from_pretrained("<hf-repo-id>")` |
+| SatMAE | `from rshf.satmae import SatMAE` | `model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")` |
+| SatMAE multi-spectral pretrain | `from rshf.satmae import SatMAE_Pre_MS` | `model = SatMAE_Pre_MS.from_pretrained("<hf-repo-id>")` |
+| SatMAE multi-spectral finetune | `from rshf.satmae import SatMAE_Fine_MS` | `model = SatMAE_Fine_MS.from_pretrained("<hf-repo-id>")` |
+| SatMAE++ | `from rshf.satmaepp import SatMAEPP` | `model = SatMAEPP.from_pretrained("<hf-repo-id>")` |
+| ScaleMAE | `from rshf.scalemae import ScaleMAE` | `model = ScaleMAE.from_pretrained("<hf-repo-id>")` |
+| SenCLIP | `from rshf.senclip import SenCLIP` | `model = SenCLIP.from_pretrained("<hf-repo-id>")` |
+| SINR | `from rshf.sinr import SINR` | `model = SINR.from_pretrained("<hf-repo-id>")` |
+| StreetCLIP | `from rshf.streetclip import StreetCLIP` | `model = StreetCLIP.from_pretrained("<hf-repo-id>")` |
+| TaxaBind | `from rshf.taxabind import TaxaBind` | `model = TaxaBind(config)` |
+
+### Additional CLIP components
+
+```python
+from rshf.clip import CLIPProcessor, CLIPTextModel, CLIPVisionModel
+
+processor = CLIPProcessor.from_pretrained("<hf-repo-id>")
+text_encoder = CLIPTextModel.from_pretrained("<hf-repo-id>")
+vision_encoder = CLIPVisionModel.from_pretrained("<hf-repo-id>")
+```
+
+## Package functions and helpers
+
+### `rshf.list_models(model_name: str) -> None`
+
+Print repositories from the curated collection whose IDs contain `model_name`.
+
+```python
+from rshf import list_models
+
+list_models("geoclip")
+```
+
+### `rshf.from_config(model_class, repo_id, revision=None, **kwargs)`
+
+Download `config.json` from a model repo and instantiate a model with random
+weights (architecture only, no pretrained checkpoint weights).
+
+```python
+from rshf import from_config
+from rshf.satmae import SatMAE
+
+model = from_config(SatMAE, "MVRL/satmae-vitlarge-fmow-pretrain-800")
+```
+
+### `rshf.utils.help(model) -> None`
+
+Print a model class docstring.
+
+```python
+from rshf.utils import help as print_help
+from rshf.sinr import SINR
+
+print_help(SINR)
+```
+
+### SINR utilities
+
+```python
+from rshf.sinr import SINR, SINRConfig, preprocess_locs
+
+model = SINR.from_pretrained("<hf-repo-id>")
+locs = preprocess_locs(...)
+embeddings = model(locs)
+```
+
+### GeoCLIP config utility
+
+```python
+from rshf.geoclip import GeoCLIP, GeoCLIPConfig
+
+config = GeoCLIPConfig(sigma=[2, 4], input_size=2, encoded_size=256, dim=512)
+model = GeoCLIP(config)
+```
+
+### TaxaBind loader functions
+
+`TaxaBind` is config-driven and exposes dedicated getters:
+
+- `get_image_text_encoder()`
+- `get_tokenizer()`
+- `get_image_processor()`
+- `get_audio_encoder()`
+- `get_audio_processor()`
+- `get_location_encoder()`
+- `get_env_encoder()`
+- `get_sat_encoder()`
+- `get_sat_processor()`
+- `process_audio(track, sr)`
+
+## Citations
+
+Model-specific references are available in each model folder:
+
+- `rshf/bioclip/README.md`
+- `rshf/climplicit/README.md`
+- `rshf/clip/README.md`
+- `rshf/croma/README.md`
+- `rshf/dinov3_sat/README.md`
+- `rshf/geoclap/README.md`
+- `rshf/geoclip/README.md`
+- `rshf/presto/README.md`
+- `rshf/prithvi/README.md`
+- `rshf/prom3e/README.md`
+- `rshf/rcme/README.md`
+- `rshf/remoteclip/README.md`
+- `rshf/rvsa/README.md`
+- `rshf/sat2cap/README.md`
+- `rshf/satclip/README.md`
+- `rshf/satmae/README.md`
+- `rshf/satmaepp/README.md`
+- `rshf/scalemae/README.MD`
+- `rshf/senclip/README.md`
+- `rshf/sinr/README.md`
+- `rshf/streetclip/README.md`
+- `rshf/taxabind/README.md`

--- a/README.md
+++ b/README.md
@@ -1,179 +1,53 @@
 # rshf
-
 [![PyPI - Version](https://img.shields.io/pypi/v/rshf)](https://pypi.org/project/rshf/)
 [![PyPI Downloads](https://static.pepy.tech/badge/rshf)](https://pypistats.org/packages/rshf)
 [![PyPI Docs](https://img.shields.io/readthedocs/rshf)](https://rshf-docs.readthedocs.io/en/latest/)
 
-`rshf` provides a single Python package for loading remote sensing foundation
-models from Hugging Face and related backends.
 
-This documentation focuses on:
+### Remote sensing pretrained models easy loading using huggingface -- PyTorch (for fast benchmarking)
 
-1. How to load every model exposed by `rshf`.
-2. What utility functions are available in the package.
-
-## Installation
-
+### Installation:
 ```bash
 pip install rshf
 ```
 
-## Quick start
-
+### Example:
 ```python
-from rshf import list_models
 from rshf.satmae import SatMAE
-
-# Print matching model repositories in the curated collection.
-list_models("satmae")
-
-# Load pretrained weights.
 model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")
+input = model.transform(torch.randint(0, 256, (224, 224, 3)).float().numpy(), 224).unsqueeze(0)
+print(model.forward_encoder(input, mask_ratio=0.0)[0].shape)
 ```
 
-## Model loading reference
+### TODO:
+- [ ] Add transforms for each model
+- [ ] Add Documentation (https://rshf-docs.readthedocs.io/en/latest/)
+- [x] Add initial set of models
 
-Most classes in `rshf` are loaded with:
+### Citations
 
-```python
-model = ModelClass.from_pretrained("<hf-repo-id>")
-```
-
-Use `list_models("<keyword>")` to discover matching repositories in the
-collection:
-https://huggingface.co/collections/MVRL/remote-sensing-foundation-models-664e8fcd67d8ca8c03f42d00
-
-### Per-model imports and loaders
-
-| Model | Import | Load |
-|---|---|---|
-| BioCLIP | `from rshf.bioclip import BioCLIP` | `model = BioCLIP()` |
-| Climplicit | `from rshf.climplicit import Climplicit` | `model = Climplicit.from_pretrained("<hf-repo-id>")` |
-| CLIP (generic) | `from rshf.clip import CLIPModel` | `model = CLIPModel.from_pretrained("<hf-repo-id>")` |
-| CROMA | `from rshf.croma import CROMA` | `model = CROMA.from_pretrained("<hf-repo-id>")` |
-| DinoV3 Sat | `from rshf.dinov3_sat import Dinov3_Sat` | `model = Dinov3_Sat.from_pretrained("<hf-repo-id>")` |
-| GeoCLAP | `from rshf.geoclap import GeoCLAP` | `model = GeoCLAP.from_pretrained("<hf-repo-id>")` |
-| GeoCLIP | `from rshf.geoclip import GeoCLIP` | `model = GeoCLIP.from_pretrained("<hf-repo-id>")` |
-| Presto | `from rshf.presto import Presto` | `model = Presto.from_pretrained("<hf-repo-id>")` |
-| Prithvi | `from rshf.prithvi import Prithvi` | `model = Prithvi.from_pretrained("<hf-repo-id>")` |
-| ProM3E | `from rshf.prom3e import ProM3E` | `model = ProM3E.from_pretrained("<hf-repo-id>")` |
-| RCME | `from rshf.rcme import RCME` | `model = RCME()` |
-| RemoteCLIP | `from rshf.remoteclip import RemoteCLIP` | `model = RemoteCLIP("ViT-B-32")` |
-| RVSA | `from rshf.rvsa import RVSA` | `model = RVSA.from_pretrained("<hf-repo-id>")` |
-| Sat2Cap (vision encoder) | `from rshf.sat2cap import Sat2Cap` | `model = Sat2Cap.from_pretrained("<hf-repo-id>")` |
-| SatClip | `from rshf.satclip import SatClip` | `model = SatClip.from_pretrained("<hf-repo-id>")` |
-| SatMAE | `from rshf.satmae import SatMAE` | `model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")` |
-| SatMAE multi-spectral pretrain | `from rshf.satmae import SatMAE_Pre_MS` | `model = SatMAE_Pre_MS.from_pretrained("<hf-repo-id>")` |
-| SatMAE multi-spectral finetune | `from rshf.satmae import SatMAE_Fine_MS` | `model = SatMAE_Fine_MS.from_pretrained("<hf-repo-id>")` |
-| SatMAE++ | `from rshf.satmaepp import SatMAEPP` | `model = SatMAEPP.from_pretrained("<hf-repo-id>")` |
-| ScaleMAE | `from rshf.scalemae import ScaleMAE` | `model = ScaleMAE.from_pretrained("<hf-repo-id>")` |
-| SenCLIP | `from rshf.senclip import SenCLIP` | `model = SenCLIP.from_pretrained("<hf-repo-id>")` |
-| SINR | `from rshf.sinr import SINR` | `model = SINR.from_pretrained("<hf-repo-id>")` |
-| StreetCLIP | `from rshf.streetclip import StreetCLIP` | `model = StreetCLIP.from_pretrained("<hf-repo-id>")` |
-| TaxaBind | `from rshf.taxabind import TaxaBind` | `model = TaxaBind(config)` |
-
-### Additional CLIP components
-
-```python
-from rshf.clip import CLIPProcessor, CLIPTextModel, CLIPVisionModel
-
-processor = CLIPProcessor.from_pretrained("<hf-repo-id>")
-text_encoder = CLIPTextModel.from_pretrained("<hf-repo-id>")
-vision_encoder = CLIPVisionModel.from_pretrained("<hf-repo-id>")
-```
-
-## Package functions and helpers
-
-### `rshf.list_models(model_name: str) -> None`
-
-Print repositories from the curated collection whose IDs contain `model_name`.
-
-```python
-from rshf import list_models
-
-list_models("geoclip")
-```
-
-### `rshf.from_config(model_class, repo_id, revision=None, **kwargs)`
-
-Download `config.json` from a model repo and instantiate a model with random
-weights (architecture only, no pretrained checkpoint weights).
-
-```python
-from rshf import from_config
-from rshf.satmae import SatMAE
-
-model = from_config(SatMAE, "MVRL/satmae-vitlarge-fmow-pretrain-800")
-```
-
-### `rshf.utils.help(model) -> None`
-
-Print a model class docstring.
-
-```python
-from rshf.utils import help as print_help
-from rshf.sinr import SINR
-
-print_help(SINR)
-```
-
-### SINR utilities
-
-```python
-from rshf.sinr import SINR, SINRConfig, preprocess_locs
-
-model = SINR.from_pretrained("<hf-repo-id>")
-locs = preprocess_locs(...)
-embeddings = model(locs)
-```
-
-### GeoCLIP config utility
-
-```python
-from rshf.geoclip import GeoCLIP, GeoCLIPConfig
-
-config = GeoCLIPConfig(sigma=[2, 4], input_size=2, encoded_size=256, dim=512)
-model = GeoCLIP(config)
-```
-
-### TaxaBind loader functions
-
-`TaxaBind` is config-driven and exposes dedicated getters:
-
-- `get_image_text_encoder()`
-- `get_tokenizer()`
-- `get_image_processor()`
-- `get_audio_encoder()`
-- `get_audio_processor()`
-- `get_location_encoder()`
-- `get_env_encoder()`
-- `get_sat_encoder()`
-- `get_sat_processor()`
-- `process_audio(track, sr)`
-
-## Citations
-
-Model-specific references are available in each model folder:
-
-- `rshf/bioclip/README.md`
-- `rshf/climplicit/README.md`
-- `rshf/clip/README.md`
-- `rshf/croma/README.md`
-- `rshf/dinov3_sat/README.md`
-- `rshf/geoclap/README.md`
-- `rshf/geoclip/README.md`
-- `rshf/presto/README.md`
-- `rshf/prithvi/README.md`
-- `rshf/prom3e/README.md`
-- `rshf/rcme/README.md`
-- `rshf/remoteclip/README.md`
-- `rshf/rvsa/README.md`
-- `rshf/sat2cap/README.md`
-- `rshf/satclip/README.md`
-- `rshf/satmae/README.md`
-- `rshf/satmaepp/README.md`
-- `rshf/scalemae/README.MD`
-- `rshf/senclip/README.md`
-- `rshf/sinr/README.md`
-- `rshf/streetclip/README.md`
-- `rshf/taxabind/README.md`
+|Model Type|Venue|Citation|
+|----------|-----|--------|
+|BioCLIP|CVPR'24|[link](./rshf/bioclip/README.md)
+|Climplicit|ICLRW'25|[link](./rshf/climplicit/README.md)
+|CLIP|ICML'21|[link](./rshf/clip/README.md)
+|CROMA|NeurIPS'23|[link](./rshf/croma/README.md)
+|DinoV3 Sat||[link](./rshf/dinov3_sat/README.md)
+|GeoCLAP|BMVC'23|[link](./rshf/geoclap/README.md)
+|GeoCLIP|NeurIPS'23|[link](./rshf/geoclip/README.md)
+|Presto||[link](./rshf/presto/README.md)
+|Prithvi||[link](./rshf/prithvi/README.md)
+|ProM3E|CVPR'26|[link](./rshf/prom3e/README.md)
+|RCME|ICCV'25|[link](./rshf/rcme/README.md)
+|RemoteCLIP|TGRS'23|[link](./rshf/remoteclip/README.md)
+|RVSA|TGRS'22|[link](./rshf/rvsa/README.md)
+|Sat2Cap|EarthVision'24|[link](./rshf/sat2cap/README.md)
+|SatClip|AAAI'25|[link](./rshf/satclip/README.md)
+|SatMAE|NeurIPS'22|[link](./rshf/satmae/README.md)
+|SatMAE++|CVPR'24|[link](./rshf/satmaepp/README.md)
+|ScaleMAE|ICCV'23|[link](./rshf/scalemae/README.md)
+|SenCLIP|WACV'25|[link](./rshf/senclip/README.md)
+|SINR|ICML'23|[link](./rshf/sinr/README.md)
+|StreetCLIP||[link](./rshf/streetclip/README.md)
+|TaxaBind|WACV'25|[link](./rshf/taxabind/README.md)
+### List of models available here: [Link](https://huggingface.co/collections/MVRL/remote-sensing-foundation-models-664e8fcd67d8ca8c03f42d00)

--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -1,16 +1,47 @@
 API Reference
 =============
 
-Top-level package:
+Core package
 
 .. automodule:: rshf
    :members:
    :undoc-members:
    :show-inheritance:
 
-Utility helpers:
+Utility helpers
 
 .. automodule:: rshf.utils
    :members:
    :undoc-members:
    :show-inheritance:
+
+Model entry-point modules
+-------------------------
+
+The following modules expose the primary model classes:
+
+- ``rshf.bioclip``
+- ``rshf.climplicit``
+- ``rshf.clip``
+- ``rshf.croma``
+- ``rshf.dinov3_sat``
+- ``rshf.geoclap``
+- ``rshf.geoclip``
+- ``rshf.presto``
+- ``rshf.prithvi``
+- ``rshf.prom3e``
+- ``rshf.rcme``
+- ``rshf.remoteclip``
+- ``rshf.rvsa``
+- ``rshf.sat2cap``
+- ``rshf.satclip``
+- ``rshf.satmae``
+- ``rshf.satmaepp``
+- ``rshf.scalemae``
+- ``rshf.senclip``
+- ``rshf.sinr``
+- ``rshf.streetclip``
+- ``rshf.taxabind``
+
+See :doc:`model_loading` for load snippets and :doc:`functions` for helper
+functions.

--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -1,15 +1,23 @@
 Installation
 ============
 
-Install the latest release from PyPI:
+Install from PyPI
+-----------------
 
 .. code-block:: bash
 
    pip install rshf
 
-Verify the installation:
+Basic import check
+------------------
 
 .. code-block:: python
 
    from rshf import list_models
-   print(len(list_models()))
+   from rshf.satmae import SatMAE
+
+   # Prints matching repositories from the curated collection.
+   list_models("satmae")
+
+   # Load a pretrained checkpoint.
+   model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")

--- a/docs/source/citations.rst
+++ b/docs/source/citations.rst
@@ -1,0 +1,89 @@
+Citations and model references
+==============================
+
+Each model family in ``rshf`` has its own reference file under the package
+source tree. The table below points to those model-specific references.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 18 54
+
+   * - Model type
+     - Venue
+     - Reference
+   * - BioCLIP
+     - CVPR'24
+     - ``rshf/bioclip/README.md``
+   * - Climplicit
+     - ICLRW'25
+     - ``rshf/climplicit/README.md``
+   * - CLIP
+     - ICML'21
+     - ``rshf/clip/README.md``
+   * - CROMA
+     - NeurIPS'23
+     - ``rshf/croma/README.md``
+   * - DinoV3 Sat
+     -
+     - ``rshf/dinov3_sat/README.md``
+   * - GeoCLAP
+     - BMVC'23
+     - ``rshf/geoclap/README.md``
+   * - GeoCLIP
+     - NeurIPS'23
+     - ``rshf/geoclip/README.md``
+   * - Presto
+     -
+     - ``rshf/presto/README.md``
+   * - Prithvi
+     -
+     - ``rshf/prithvi/README.md``
+   * - ProM3E
+     - CVPR'26
+     - ``rshf/prom3e/README.md``
+   * - RCME
+     - ICCV'25
+     - ``rshf/rcme/README.md``
+   * - RemoteCLIP
+     - TGRS'23
+     - ``rshf/remoteclip/README.md``
+   * - RVSA
+     - TGRS'22
+     - ``rshf/rvsa/README.md``
+   * - Sat2Cap
+     - EarthVision'24
+     - ``rshf/sat2cap/README.md``
+   * - SatClip
+     - AAAI'25
+     - ``rshf/satclip/README.md``
+   * - SatMAE
+     - NeurIPS'22
+     - ``rshf/satmae/README.md``
+   * - SatMAE++
+     - CVPR'24
+     - ``rshf/satmaepp/README.md``
+   * - ScaleMAE
+     - ICCV'23
+     - ``rshf/scalemae/README.MD``
+   * - SenCLIP
+     - WACV'25
+     - ``rshf/senclip/README.md``
+   * - SINR
+     - ICML'23
+     - ``rshf/sinr/README.md``
+   * - StreetCLIP
+     -
+     - ``rshf/streetclip/README.md``
+   * - TaxaBind
+     - WACV'25
+     - ``rshf/taxabind/README.md``
+
+Model collection
+----------------
+
+All published model repositories are organized under:
+
+``MVRL/remote-sensing-foundation-models-664e8fcd67d8ca8c03f42d00``
+
+See :func:`rshf.list_models` in :doc:`functions` to query this collection by
+keyword.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,9 @@ autodoc_default_options = {
     "show-inheritance": True,
 }
 
+# Allow autodoc to run in docs-only environments without full runtime deps.
+autodoc_mock_imports = ["huggingface_hub"]
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -1,0 +1,100 @@
+Functions and helpers
+=====================
+
+This page documents top-level helper functions and module-level utility
+functions exposed by ``rshf``.
+
+Top-level package functions
+---------------------------
+
+``rshf.list_models(model_name: str) -> None``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Print model repositories in the curated collection whose IDs contain
+``model_name``.
+
+.. code-block:: python
+
+   from rshf import list_models
+   list_models("geoclip")
+
+``rshf.from_config(model_class, repo_id, revision=None, **kwargs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Download ``config.json`` from a repository and instantiate ``model_class``
+using that architecture configuration with random weights.
+
+.. code-block:: python
+
+   from rshf import from_config
+   from rshf.satmae import SatMAE
+
+   model = from_config(SatMAE, "MVRL/satmae-vitlarge-fmow-pretrain-800")
+
+``rshf.utils.help(model) -> None``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Print the target model class docstring.
+
+.. code-block:: python
+
+   from rshf.utils import help as print_help
+   from rshf.sinr import SINR
+
+   print_help(SINR)
+
+SINR helpers
+------------
+
+``rshf.sinr.SINRConfig``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configuration class for constructing ``SINR`` from scratch.
+
+``rshf.sinr.preprocess_locs(locs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Convert lon/lat inputs into the sinusoidal feature representation expected by
+``SINR``.
+
+.. code-block:: python
+
+   import torch
+   from rshf.sinr import SINR, preprocess_locs
+
+   model = SINR.from_pretrained("<hf-repo-id>")
+   locs = torch.tensor([[-80.0, 40.0]], dtype=torch.float32)
+   features = preprocess_locs(locs)
+   embeddings = model(features)
+
+GeoCLIP helpers
+---------------
+
+``rshf.geoclip.GeoCLIPConfig``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configuration class for constructing ``GeoCLIP`` from scratch.
+
+.. code-block:: python
+
+   from rshf.geoclip import GeoCLIP, GeoCLIPConfig
+
+   config = GeoCLIPConfig(sigma=[2, 4], input_size=2, encoded_size=256, dim=512)
+   model = GeoCLIP(config)
+
+TaxaBind helper methods
+-----------------------
+
+``TaxaBind`` is initialized with configuration and provides modular getter
+functions:
+
+- ``get_image_text_encoder()``
+- ``get_tokenizer()``
+- ``get_image_processor()``
+- ``get_audio_encoder()``
+- ``get_audio_processor()``
+- ``process_audio(track, sr)``
+- ``get_location_encoder()``
+- ``get_env_encoder()``
+- ``get_sat_encoder()``
+- ``get_sat_processor()``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,4 +12,5 @@ related encoders.
    usage
    model_loading
    functions
+   citations
    API

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,15 @@
-rshf Documentation
+rshf documentation
 ==================
 
-`rshf` provides lightweight loading helpers for remote sensing foundation
-models hosted on Hugging Face.
+`rshf` is a unified interface for loading remote sensing foundation models and
+related encoders.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents
 
-   installation
+   Installation
    usage
-   api
+   model_loading
+   functions
+   API

--- a/docs/source/model_loading.rst
+++ b/docs/source/model_loading.rst
@@ -1,0 +1,115 @@
+Model loading guide
+===================
+
+This page documents how to load each model exported by ``rshf``.
+
+Discover repository IDs
+-----------------------
+
+When a model uses ``from_pretrained``, pass a Hugging Face repository ID.
+You can find matching IDs in the curated collection with:
+
+.. code-block:: python
+
+   from rshf import list_models
+   list_models("satmae")
+
+The underlying collection is:
+``MVRL/remote-sensing-foundation-models-664e8fcd67d8ca8c03f42d00``.
+
+Per-model loading reference
+---------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 34 44
+
+   * - Model
+     - Import
+     - Load
+   * - BioCLIP
+     - ``from rshf.bioclip import BioCLIP``
+     - ``model = BioCLIP()``
+   * - Climplicit
+     - ``from rshf.climplicit import Climplicit``
+     - ``model = Climplicit.from_pretrained("<hf-repo-id>")``
+   * - CLIP
+     - ``from rshf.clip import CLIPModel``
+     - ``model = CLIPModel.from_pretrained("<hf-repo-id>")``
+   * - CROMA
+     - ``from rshf.croma import CROMA``
+     - ``model = CROMA.from_pretrained("<hf-repo-id>")``
+   * - DinoV3 Sat
+     - ``from rshf.dinov3_sat import Dinov3_Sat``
+     - ``model = Dinov3_Sat.from_pretrained("<hf-repo-id>")``
+   * - GeoCLAP
+     - ``from rshf.geoclap import GeoCLAP``
+     - ``model = GeoCLAP.from_pretrained("<hf-repo-id>")``
+   * - GeoCLIP
+     - ``from rshf.geoclip import GeoCLIP``
+     - ``model = GeoCLIP.from_pretrained("<hf-repo-id>")``
+   * - Presto
+     - ``from rshf.presto import Presto``
+     - ``model = Presto.from_pretrained("<hf-repo-id>")``
+   * - Prithvi
+     - ``from rshf.prithvi import Prithvi``
+     - ``model = Prithvi.from_pretrained("<hf-repo-id>")``
+   * - ProM3E
+     - ``from rshf.prom3e import ProM3E``
+     - ``model = ProM3E.from_pretrained("<hf-repo-id>")``
+   * - RCME
+     - ``from rshf.rcme import RCME``
+     - ``model = RCME()``
+   * - RemoteCLIP
+     - ``from rshf.remoteclip import RemoteCLIP``
+     - ``model = RemoteCLIP("ViT-B-32")``
+   * - RVSA
+     - ``from rshf.rvsa import RVSA``
+     - ``model = RVSA.from_pretrained("<hf-repo-id>")``
+   * - Sat2Cap
+     - ``from rshf.sat2cap import Sat2Cap``
+     - ``model = Sat2Cap.from_pretrained("<hf-repo-id>")``
+   * - SatClip
+     - ``from rshf.satclip import SatClip``
+     - ``model = SatClip.from_pretrained("<hf-repo-id>")``
+   * - SatMAE
+     - ``from rshf.satmae import SatMAE``
+     - ``model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")``
+   * - SatMAE multi-spectral pretrain
+     - ``from rshf.satmae import SatMAE_Pre_MS``
+     - ``model = SatMAE_Pre_MS.from_pretrained("<hf-repo-id>")``
+   * - SatMAE multi-spectral finetune
+     - ``from rshf.satmae import SatMAE_Fine_MS``
+     - ``model = SatMAE_Fine_MS.from_pretrained("<hf-repo-id>")``
+   * - SatMAE++
+     - ``from rshf.satmaepp import SatMAEPP``
+     - ``model = SatMAEPP.from_pretrained("<hf-repo-id>")``
+   * - ScaleMAE
+     - ``from rshf.scalemae import ScaleMAE``
+     - ``model = ScaleMAE.from_pretrained("<hf-repo-id>")``
+   * - SenCLIP
+     - ``from rshf.senclip import SenCLIP``
+     - ``model = SenCLIP.from_pretrained("<hf-repo-id>")``
+   * - SINR
+     - ``from rshf.sinr import SINR``
+     - ``model = SINR.from_pretrained("<hf-repo-id>")``
+   * - StreetCLIP
+     - ``from rshf.streetclip import StreetCLIP``
+     - ``model = StreetCLIP.from_pretrained("<hf-repo-id>")``
+   * - TaxaBind
+     - ``from rshf.taxabind import TaxaBind``
+     - ``model = TaxaBind(config)``
+
+Additional CLIP exports
+-----------------------
+
+The ``rshf.clip`` module also exports ``CLIPProcessor``, ``CLIPTextModel``,
+and ``CLIPVisionModel``:
+
+.. code-block:: python
+
+   from rshf.clip import CLIPProcessor, CLIPTextModel, CLIPVisionModel
+
+   processor = CLIPProcessor.from_pretrained("<hf-repo-id>")
+   text_encoder = CLIPTextModel.from_pretrained("<hf-repo-id>")
+   vision_encoder = CLIPVisionModel.from_pretrained("<hf-repo-id>")

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,15 +1,41 @@
 Usage
 =====
 
-Minimal example:
+This page covers the common loading patterns used across the package.
+For an exhaustive per-model list, see :doc:`model_loading`.
+
+Common loading pattern
+----------------------
+
+Most `rshf` classes are loaded through Hugging Face Hub:
 
 .. code-block:: python
 
-   import torch
    from rshf.satmae import SatMAE
 
    model = SatMAE.from_pretrained("MVRL/satmae-vitlarge-fmow-pretrain-800")
-   image = torch.randint(0, 256, (224, 224, 3)).float().numpy()
-   batch = model.transform(image, 224).unsqueeze(0)
-   embedding = model.forward_encoder(batch, mask_ratio=0.0)[0]
-   print(embedding.shape)
+
+Finding available repositories
+------------------------------
+
+Use :func:`rshf.list_models` with a keyword:
+
+.. code-block:: python
+
+   from rshf import list_models
+
+   list_models("geoclip")
+   list_models("satmae")
+
+Building from architecture config only
+--------------------------------------
+
+Use :func:`rshf.from_config` when you want random initialization with a known
+model architecture:
+
+.. code-block:: python
+
+   from rshf import from_config
+   from rshf.satmae import SatMAE
+
+   model = from_config(SatMAE, "MVRL/satmae-vitlarge-fmow-pretrain-800")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- moved comprehensive package documentation into ReadTheDocs pages under `docs/source`
- added a dedicated `citations` page and linked it in docs navigation
- kept model-loading and function documentation in ReadTheDocs (`model_loading`, `functions`, `usage`, `API`)
- restored `README.md` to its original content
- kept docs build support in `conf.py` by mocking `huggingface_hub` for autodoc

## Testing
- `python3 -m sphinx -b html docs/source docs/_build/html`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-005862f3-e736-4508-8e5e-23e523b8e849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-005862f3-e736-4508-8e5e-23e523b8e849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

